### PR TITLE
solving issue 4, popovers now hide apart from one that has been click…

### DIFF
--- a/public/resources/javascript/main.js
+++ b/public/resources/javascript/main.js
@@ -1,2 +1,2 @@
-require('bootstrap')
-require('./setup/popover')()
+require('bootstrap');
+require('./setup/popover')();

--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -1,20 +1,22 @@
 /*
- * Bootstrap popovers and tooltips
- */
+* Bootstrap popovers and tooltips
+*/
 
 
-var $ = require('jquery')
+var $ = require('jquery');
 
 
 module.exports = function () {
 
-    // initialise all popovers
-    $('body').popover({
-        selector: '[data-toggle="popover"]',
-        container: 'body',
-        viewport: { selector: 'body', padding: 20 }
-    })
-    
-    // Initialise Bootstrap tooltips
-    $('[data-toggle="tooltip"]').tooltip()
-}
+  // initialise all popovers
+  $('body').popover({
+    selector: '[data-toggle="popover"]',
+    container: 'body',
+    viewport: { selector: 'body', padding: 20 }
+  }).on("show.bs.popover", function(e){
+     $('.popover').not(this).popover('hide');
+  });
+
+  // Initialise Bootstrap tooltips
+  $('[data-toggle="tooltip"]').tooltip();
+};

--- a/public/resources/javascript/shim.js
+++ b/public/resources/javascript/shim.js
@@ -1,11 +1,9 @@
 module.exports = {
-    'jquery': {
-        exports: 'jQuery'
+  'jquery': {
+    exports: 'jQuery'
+  }, 'bootstrap': {
+    depends: {
+      jquery: 'jQuery'
     }
-
-    , 'bootstrap': {
-        depends: {
-            jquery: 'jQuery'
-        }
-    }
-}
+  }
+};


### PR DESCRIPTION
**Updates**

This PR updates the popover visibility so that only the most recently selected shows, with all others disappearing.
I edited the popover.js file only.
I have worked with info boxes in JavaScript so I was able to easily locate the part of the code which needed working on. I then used Stack Overflow to research how to hide the popovers in PHP.

---

**Testing**

Tell us how we should test your work. What steps do we need to take. What has changed?

In the browser click on an episode image and the poppover box will appear. When you select another image, you will see a new popover box and the first one will disappear.
---

**Deployment steps**

Tell us what we would need to do to get your changes into production. (We are aware that in this test, this is mostly a case of merging your branch). e.g.

Merge branch `issue4` into `development` and then `development` into `master` branch.

Compile assets: `./bin/node_modules/gulp`
